### PR TITLE
nxp: nfc: enable global guard for NQ NFC devices

### DIFF
--- a/nfc_vendor_product.mk
+++ b/nfc_vendor_product.mk
@@ -1,16 +1,8 @@
+ifeq ($(strip $(TARGET_USES_NQ_NFC)),true)
 # Enable build support for NFC open source vendor modules
-ifeq ($(call is-board-platform-in-list, sdm845 sdm710 msmnile $(MSMSTEPPE) $(TRINKET) kona lito bengal atoll lahaina holi monaco),true)
-TARGET_USES_NQ_NFC := true
-# Disable NFC on targets matching the TARGET_PRODUCT value in the list
-ifeq ($(filter $(TARGET_PRODUCT), bengal_32 bengal_32go),$(TARGET_PRODUCT))
-TARGET_USES_NQ_NFC := false
-endif
-endif
-
 NQ_VENDOR_NFC += vendor.nxp.hardware.nfc@2.0-service
 NQ_VENDOR_NFC += nfc_nci.nqx.default.hw
 
-ifeq ($(strip $(TARGET_USES_NQ_NFC)),true)
 PRODUCT_COPY_FILES += \
     frameworks/native/data/etc/com.nxp.mifare.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/com.nxp.mifare.xml \
     frameworks/native/data/etc/com.android.nfc_extras.xml:$(TARGET_COPY_OUT_VENDOR)/etc/permissions/com.android.nfc_extras.xml \


### PR DESCRIPTION
* Tested, works fine